### PR TITLE
Add "Enable beacon overload mechanic" mod option

### DIFF
--- a/wret-beacon-rebalance-mod/locale/en/locale.cfg
+++ b/wret-beacon-rebalance-mod/locale/en/locale.cfg
@@ -22,6 +22,7 @@ beacon2-item=Beacon Mk2
 beacon3-item=Beacon Mk3
 
 [mod-setting-name]
+wret-overload-beacons=Enable beacon overload mechanic
 wret-overload-enable-beaconmk2=Enable Beacon Mk2
 wret-overload-enable-beaconmk3=Enable Beacon Mk3
 wret-overload-enable-notnotmelon-style=Enable alternate Beacon Mk1 balance

--- a/wret-beacon-rebalance-mod/settings.lua
+++ b/wret-beacon-rebalance-mod/settings.lua
@@ -1,6 +1,13 @@
 data:extend({
 	{
 		type = "bool-setting",
+		name = "wret-overload-beacons",
+		setting_type = "startup",
+		default_value = true,
+		order = "0",
+	},
+	{
+		type = "bool-setting",
 		name = "wret-overload-keep-vanilla-sprite-mk1",
 		setting_type = "startup",
 		default_value = false,


### PR DESCRIPTION
I found the beacon overload mechanic difficult to reliably work with the Warp Drive Machine mod, so a toggle to disable that functionality